### PR TITLE
fix(insert): only fetch state ID when inserting dataset

### DIFF
--- a/chimedb/dataset/insert.py
+++ b/chimedb/dataset/insert.py
@@ -78,12 +78,12 @@ def insert_dataset(ds_id, base_dset, is_root, state, time):
     DatasetState.DoesNotExist
         If the state attached to the dataset is not found in the database.
     """
-    state = DatasetState.get(DatasetState.id == state)
     try:
         Dataset.get(Dataset.id == ds_id)
     except Dataset.DoesNotExist:
         if base_dset:
             Dataset.get(Dataset.id == base_dset)
+        state = DatasetState.select(DatasetState.id).get(DatasetState.id == state)
         Dataset.get_or_create(
             id=ds_id, state=state, root=is_root, time=time, base_dset=base_dset,
         )

--- a/chimedb/dataset/insert.py
+++ b/chimedb/dataset/insert.py
@@ -77,6 +77,8 @@ def insert_dataset(ds_id, base_dset, is_root, state, time):
     ------
     DatasetState.DoesNotExist
         If the state attached to the dataset is not found in the database.
+    Dataset.DoesNotExist
+        If the base dataset is not found in the database.
     """
     try:
         Dataset.get(Dataset.id == ds_id)


### PR DESCRIPTION
Instead of fetching the hole state, only fetch ID.

Fixes chime-experiment/comet/issues/74