### PR TITLE
Fix insert_dataset ...again

### DIFF
--- a/chimedb/dataset/insert.py
+++ b/chimedb/dataset/insert.py
@@ -85,7 +85,9 @@ def insert_dataset(ds_id, base_dset, is_root, state, time):
     except Dataset.DoesNotExist:
         if base_dset:
             Dataset.get(Dataset.id == base_dset)
-        state = DatasetState.select(DatasetState.id).get(DatasetState.id == state)
+        state = (
+            DatasetState.select(DatasetState.id).where(DatasetState.id == state).get()
+        )
         Dataset.get_or_create(
             id=ds_id, state=state, root=is_root, time=time, base_dset=base_dset,
         )


### PR DESCRIPTION
second attempt to fix https://github.com/chime-experiment/comet/issues/74

The previous attempt lead to
```
  File "/home/rick/comet/comet/archiver.py", line 200, in _insert_dataset
    db.insert_dataset(ds_id, base_dset, is_root, state, timestamp)
  File "/home/rick/chimedb_ds/chimedb/dataset/insert.py", line 89, in insert_dataset
    DatasetState.select(DatasetState.id).get(DatasetState.id == state)
  File "/home/rick/.local/lib/python3.7/site-packages/peewee.py", line 6445, in get
    return clone.execute(database)[0]
  File "/home/rick/.local/lib/python3.7/site-packages/peewee.py", line 1785, in inner
    return method(self, database, *args, **kwargs)
  File "/home/rick/.local/lib/python3.7/site-packages/peewee.py", line 1856, in execute
    return self._execute(database)
  File "/home/rick/.local/lib/python3.7/site-packages/peewee.py", line 2027, in _execute
    cursor = database.execute(self)
AttributeError: 'Expression' object has no attribute 'execute'

```