### PR TITLE
Clean up orm/get classes in chimedb.dataset.get

### DIFF
--- a/chimedb/dataset/get.py
+++ b/chimedb/dataset/get.py
@@ -223,7 +223,7 @@ class Dataset(orm.Dataset):
         state_id = orm_base_class.state_id
 
         if state_id not in _state_cache:
-            _state_cache[state_id] = orm_base_class.state
+            _state_cache[state_id] = DatasetState.from_id(state_id)
         return _state_cache[state_id]
 
     def __repr__(self):

--- a/chimedb/dataset/get.py
+++ b/chimedb/dataset/get.py
@@ -13,7 +13,7 @@ from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
 import warnings
 
 from . import orm
-from chimedb.core.exceptions import NotFoundError
+from chimedb.core.exceptions import NotFoundError, ValidationError
 
 # Logging
 # =======
@@ -189,6 +189,10 @@ class Dataset(orm.Dataset):
         Dataset
             The requested dataset.
         """
+        if not isinstance(ds_id, str):
+            raise ValidationError(
+                "ds_id is of type {} (expected str)".format(type(ds_id).__name__)
+            )
         if ds_id not in _dataset_cache:
             try:
                 _dataset_cache[ds_id] = Dataset.get(Dataset.id == ds_id)

--- a/chimedb/dataset/get.py
+++ b/chimedb/dataset/get.py
@@ -211,8 +211,8 @@ class Dataset(orm.Dataset):
     @property
     def base_dataset(self):
         """Get the base dataset."""
-        if not self._base_dataset:
-            self._base_dataset = self.base_dset
+        if not self._base_dataset and not self.root:
+            self._base_dataset = Dataset.from_id(self.base_dset_id)
         return self._base_dataset
 
     @property

--- a/chimedb/dataset/get.py
+++ b/chimedb/dataset/get.py
@@ -169,7 +169,9 @@ class Dataset(orm.Dataset):
     functionality.
     """
 
+    # state type name
     _type = None
+
     _base_dataset = None
 
     @classmethod
@@ -204,9 +206,7 @@ class Dataset(orm.Dataset):
     @property
     def type(self):
         """Get the type of the attached dataset state."""
-        if self._type is None:
-            return self.dataset_state.type
-        return self._type
+        return self.dataset_state.state_type
 
     @property
     def base_dataset(self):
@@ -228,7 +228,7 @@ class Dataset(orm.Dataset):
 
     def __repr__(self):
         if self._type:
-            return "<get.Dataset[{}]: {}>".format(self.type, self.id)
+            return "<get.Dataset[{}]: {}>".format(self._type, self.id)
         else:
             return "<get.Dataset: {}>".format(self.id)
 
@@ -255,7 +255,6 @@ class Dataset(orm.Dataset):
             type_ = DatasetStateType.from_name(name=type_)
             if type_ is None:
                 raise NotFoundError("{} is not a known DatasetStateType".format(type_))
-            type_ = type_.name
         d = self
 
         while d:
@@ -264,7 +263,9 @@ class Dataset(orm.Dataset):
             d = d.base_dataset
 
         raise NotFoundError(
-            "No ancestor of type {} found for Dataset {}".format(type_, self.__repr__())
+            "No ancestor of type {} found for Dataset {}".format(
+                type_.name, self.__repr__()
+            )
         )
 
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -4,39 +4,67 @@ import chimedb.dataset.get as dget
 import chimedb.dataset.orm as orm
 from chimedb.dataset.testing import TestChimeDB
 
-
 import datetime
+from peewee import DoesNotExist
 
 
 class TestDataset(TestChimeDB):
     """Test using test_enable() for testing"""
 
-    def test_get_dataset(self):
+    def setUp(self):
+        super().setUp()
         # insert test data type in DB
         state_type, _ = orm.DatasetStateType.get_or_create(name="twentythree")
-        state_type = state_type
 
-        orm.DatasetState.get_or_create(
-            id="23",
-            type=state_type.id,
-            data={"twenty": 3},
-            time=datetime.datetime.now(),
-        )
-        orm.Dataset.get_or_create(
-            id="1337",
-            root=True,
-            state="23",
-            time=datetime.datetime.now(),
-            base_dset=None,
-        )
+        try:
+            orm.DatasetState.get(id="23")
+        except DoesNotExist:
+            orm.DatasetState.get_or_create(
+                id="23",
+                type=state_type.id,
+                data={"twenty": 3},
+                time=datetime.datetime.now(),
+            )
+        try:
+            ds_ = orm.Dataset.get(id="1337")
+        except DoesNotExist:
+            ds_, _ = orm.Dataset.get_or_create(
+                id="1337",
+                root=True,
+                state="23",
+                time=datetime.datetime.now(),
+                base_dset=None,
+            )
 
-        # pre-fetch
-        dget.index()
-        assert "1337" in dget._dataset_cache
-        assert "23" in dget._state_cache
+        # insert test data type 2 in DB
+        state_type2, _ = orm.DatasetStateType.get_or_create(name="twentyfour")
 
+        try:
+            orm.DatasetState.get(id="24")
+        except DoesNotExist:
+            orm.DatasetState.get_or_create(
+                id="24",
+                type=state_type2.id,
+                data={"twenty": 4},
+                time=datetime.datetime.now(),
+            )
+        try:
+            ds_ = orm.Dataset.get(id="1338")
+        except DoesNotExist:
+            orm.Dataset.get_or_create(
+                id="1338",
+                root=False,
+                state="24",
+                time=datetime.datetime.now(),
+                base_dset=ds_,
+            )
+
+    def test_get_dataset(self):
         ds = dget.Dataset.from_id("1337")
-        assert ds.__repr__() == "<get.Dataset[twentythree]: 1337>"
+        assert (
+            ds.__repr__() == "<get.Dataset: 1337>"
+            or ds.__repr__() == "<get.Dataset[twentythree]: 1337>"
+        )
         assert ds.base_dataset is None
         assert ds.root is True
 
@@ -46,3 +74,21 @@ class TestDataset(TestChimeDB):
         ss = ds.closest_ancestor_of_type(type_="twentythree").state
         assert ss.__repr__() == "<DatasetState: 23>"
         assert ss.type.name == "twentythree"
+
+    def test_get_root_dataset(self):
+        # pre-fetch
+        dget.index()
+        assert "1338" in dget._dataset_cache
+        assert "24" in dget._state_cache
+
+        ds = dget.Dataset.from_id("1338")
+        assert ds.__repr__() == "<get.Dataset[twentyfour]: 1338>"
+        assert ds.base_dataset is not None
+        assert ds.root is False
+
+        state = dget.DatasetState.from_id("24")
+        assert state.__repr__() == "<get.DatasetState[twentyfour]: 24>"
+
+        ss = ds.closest_ancestor_of_type(type_="twentyfour").state
+        assert ss.__repr__() == "<DatasetState: 24>"
+        assert ss.type.name == "twentyfour"

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -59,36 +59,50 @@ class TestDataset(TestChimeDB):
                 base_dset=ds_,
             )
 
-    def test_get_dataset(self):
-        ds = dget.Dataset.from_id("1337")
-        assert (
-            ds.__repr__() == "<get.Dataset: 1337>"
-            or ds.__repr__() == "<get.Dataset[twentythree]: 1337>"
-        )
-        assert ds.base_dataset is None
-        assert ds.root is True
+    def test_get_dataset_no_prefetch(self):
+        def tests():
+            ds = dget.Dataset.from_id("1337")
+            assert (
+                ds.__repr__() == "<get.Dataset: 1337>"
+                or ds.__repr__() == "<get.Dataset[twentythree]: 1337>"
+            )
+            assert ds.base_dataset is None
+            assert ds.root is True
 
-        state = dget.DatasetState.from_id("23")
-        assert state.__repr__() == "<get.DatasetState[twentythree]: 23>"
+            state = dget.DatasetState.from_id("23")
+            assert state.__repr__() == "<get.DatasetState[twentythree]: 23>"
 
-        ss = ds.closest_ancestor_of_type(type_="twentythree").state
-        assert ss.__repr__() == "<DatasetState: 23>"
-        assert ss.type.name == "twentythree"
+            ss = ds.closest_ancestor_of_type(type_="twentythree").state
+            assert ss.__repr__() == "<DatasetState: 23>"
+            assert ss.type.name == "twentythree"
 
-    def test_get_root_dataset(self):
+            assert ss.data == {"twenty": 3}
+
+        tests()
+
         # pre-fetch
         dget.index()
-        assert "1338" in dget._dataset_cache
-        assert "24" in dget._state_cache
+        tests()
 
-        ds = dget.Dataset.from_id("1338")
-        assert ds.__repr__() == "<get.Dataset[twentyfour]: 1338>"
-        assert ds.base_dataset is not None
-        assert ds.root is False
+    def test_get_root_dataset_no_prefetch(self):
+        def tests():
+            assert "1338" in dget._dataset_cache
+            assert "24" in dget._state_cache
 
-        state = dget.DatasetState.from_id("24")
-        assert state.__repr__() == "<get.DatasetState[twentyfour]: 24>"
+            ds = dget.Dataset.from_id("1338")
+            assert ds.__repr__() == "<get.Dataset[twentyfour]: 1338>"
+            assert ds.base_dataset is not None
+            assert ds.root is False
 
-        ss = ds.closest_ancestor_of_type(type_="twentyfour").state
-        assert ss.__repr__() == "<DatasetState: 24>"
-        assert ss.type.name == "twentyfour"
+            state = dget.DatasetState.from_id("24")
+            assert state.__repr__() == "<get.DatasetState[twentyfour]: 24>"
+
+            ss = ds.closest_ancestor_of_type(type_="twentyfour").state
+            assert ss.__repr__() == "<DatasetState: 24>"
+            assert ss.type.name == "twentyfour"
+
+        tests()
+
+        # pre-fetch
+        dget.index()
+        tests()


### PR DESCRIPTION
- If data wasn't pre-fetched, the `orm` (low level) state was used as `get.Dataset.dataset_state` -> always use `get.DatasetState` here
- If data wasn't pre-fetched, the state type name was used as `get.Dataset.type` instead of the type object -> always use `get.DatasetStateType` here
- add check for types of the parameters of `get.Dataset.from_id`
- add tests