### PR TITLE
feat(utils): routines for looking up state types

### DIFF
--- a/chimedb/dataset/__init__.py
+++ b/chimedb/dataset/__init__.py
@@ -9,5 +9,17 @@ from .get import get_dataset, get_state
 
 from ._version import get_versions
 
+
 __version__ = get_versions()["version"]
 del get_versions
+
+__all__ = [
+    "Dataset",
+    "DatasetState",
+    "DatasetStateType",
+    "insert_dataset",
+    "insert_state",
+    "get_dataset",
+    "get_state",
+    "__version__",
+]

--- a/chimedb/dataset/get.py
+++ b/chimedb/dataset/get.py
@@ -1,12 +1,5 @@
 """Functions to read comet datasets and states from the database."""
 
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 # Imports
 # =======
 
@@ -78,7 +71,7 @@ class DatasetStateType(orm.DatasetStateType):
             return _type_cache[name]
 
     def __repr__(self):
-        return "<get.DatasetStateType: {}>".format(self.name)
+        return f"<get.DatasetStateType: {self.name}>"
 
 
 class DatasetState(orm.DatasetState):
@@ -110,7 +103,7 @@ class DatasetState(orm.DatasetState):
         """
         if state_id not in _state_cache.keys():
             try:
-                _logger.debug("Loading state {} from database...".format(state_id))
+                _logger.debug(f"Loading state {state_id} from database...")
                 if load_data:
                     _state_cache[state_id] = DatasetState.get(
                         DatasetState.id == state_id
@@ -120,16 +113,16 @@ class DatasetState(orm.DatasetState):
                         DatasetState.type, DatasetState.time
                     ).get()
             except orm.DatasetState.DoesNotExist:
-                _logger.warning("Could not find state {}.".format(state_id))
+                _logger.warning(f"Could not find state {state_id}.")
                 return None
         return _state_cache[state_id]
 
     def __repr__(self):
         type_ = self.state_type
         if type_ is not None:
-            return "<get.DatasetState[{}]: {}>".format(type_.name, self.id)
+            return f"<get.DatasetState[{type_.name}]: {self.id}>"
         else:
-            return "<get.DatasetState: {}>".format(self.id)
+            return f"<get.DatasetState: {self.id}>"
 
     @property
     def state_type(self):
@@ -194,13 +187,13 @@ class Dataset(orm.Dataset):
         """
         if not isinstance(ds_id, str):
             raise ValidationError(
-                "ds_id is of type {} (expected str)".format(type(ds_id).__name__)
+                f"ds_id is of type {type(ds_id).__name__} (expected str)"
             )
         if ds_id not in _dataset_cache:
             try:
                 _dataset_cache[ds_id] = Dataset.get(Dataset.id == ds_id)
             except orm.Dataset.DoesNotExist:
-                _logger.warning("Could not find dataset {}.".format(ds_id))
+                _logger.warning(f"Could not find dataset {ds_id}.")
                 return None
         return _dataset_cache[ds_id]
 
@@ -229,9 +222,9 @@ class Dataset(orm.Dataset):
 
     def __repr__(self):
         if self._type:
-            return "<get.Dataset[{}]: {}>".format(self._type, self.id)
+            return f"<get.Dataset[{self._type}]: {self.id}>"
         else:
-            return "<get.Dataset: {}>".format(self.id)
+            return f"<get.Dataset: {self.id}>"
 
     def closest_ancestor_of_type(self, type_):
         """
@@ -255,7 +248,7 @@ class Dataset(orm.Dataset):
         if isinstance(type_, str):
             type_ = DatasetStateType.from_name(name=type_)
             if type_ is None:
-                raise NotFoundError("{} is not a known DatasetStateType".format(type_))
+                raise NotFoundError(f"{type_} is not a known DatasetStateType")
         d = self
 
         while d:

--- a/chimedb/dataset/insert.py
+++ b/chimedb/dataset/insert.py
@@ -10,8 +10,6 @@ from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
 # Imports
 # =======
 
-import datetime
-
 from .orm import DatasetStateType, DatasetState, Dataset
 
 # Logging

--- a/chimedb/dataset/insert.py
+++ b/chimedb/dataset/insert.py
@@ -1,12 +1,5 @@
 """Functions to write comet datasets and states to the database."""
 
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 # Imports
 # =======
 

--- a/chimedb/dataset/orm.py
+++ b/chimedb/dataset/orm.py
@@ -1,11 +1,4 @@
 """Table definitions for the comet datasets and states."""
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 from chimedb.core.orm import base_model, JSONDictField
 
 import peewee
@@ -29,7 +22,7 @@ class DatasetStateType(base_model):
     name = peewee.CharField()
 
     def __repr__(self):
-        return "<DatasetStateType: {}>".format(self.name)
+        return f"<DatasetStateType: {self.name}>"
 
 
 class DatasetState(base_model):

--- a/chimedb/dataset/testing.py
+++ b/chimedb/dataset/testing.py
@@ -30,7 +30,7 @@ class TestChimeDB(unittest.TestCase):
             )
 
         # Tell chimedb where the database connection config is
-        assert os.path.isfile(rcfile), "Could not find {}.".format(rcfile)
+        assert os.path.isfile(rcfile), f"Could not find {rcfile}."
         os.environ["CHIMEDB_TEST_RC"] = rcfile
 
         # Make sure we don't write to the actual chime database

--- a/chimedb/dataset/utils.py
+++ b/chimedb/dataset/utils.py
@@ -5,7 +5,7 @@ import click
 import numpy as np
 
 from chimedb.core import connect as connect_db, close as close_db
-from chimedb.dataset.get import Dataset, DatasetCache, index
+from chimedb.dataset.get import Dataset, DatasetCache
 
 
 @click.group()
@@ -98,9 +98,7 @@ def state_id_of_type(ds_ids: np.ndarray, state_type: str) -> np.ma.MaskedArray:
         if ds_id == nulldset:
             return nulldset
         else:
-            return (
-                ds.Dataset.from_id(ds_id).closest_ancestor_of_type(state_type).state.id
-            )
+            return Dataset.from_id(ds_id).closest_ancestor_of_type(state_type).state.id
 
     state_ids = np.array([_state_or_null(ds_id) for ds_id in unique_ds_ids])
 

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,6 @@
 """Tables and tools for CHIME datasets and states."""
 from setuptools import setup
 
-import codecs
-import os
-import re
 import versioneer
 
 

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
         "peewee >= 3.10",
         "future",
     ],
+    python_requires=">=3.7",
     author="CHIME collaboration",
     author_email="rick@phas.ubc.ca",
     description="CHIME dataset (comet) ORM",


### PR DESCRIPTION
This adds two routines which will be used when trying to determine gain update times from the dataset ID.

- `state_id_of_type`: given an array of dataset IDs lookup the state IDs
  for a specified state type.
- `unique_unmasked_entry`: determine if an array has a single value
  along a specified axis. This is useful for determining if a dataset ID
  is the same for all frequencies.
