### PR TITLE
fix: issue with uncached entries when using state_id_of_type

### DIFF
--- a/chimedb/dataset/utils.py
+++ b/chimedb/dataset/utils.py
@@ -98,7 +98,11 @@ def state_id_of_type(ds_ids: np.ndarray, state_type: str) -> np.ma.MaskedArray:
         if ds_id == nulldset:
             return nulldset
         else:
-            return Dataset.from_id(ds_id).closest_ancestor_of_type(state_type).state.id
+            return (
+                Dataset.from_id(str(ds_id))
+                .closest_ancestor_of_type(state_type)
+                .state.id
+            )
 
     state_ids = np.array([_state_or_null(ds_id) for ds_id in unique_ds_ids])
 


### PR DESCRIPTION
Occasionally the argument would be a string-like type, but not actually a string which would cause the queries to fail. This fixes that.