### PR TITLE
fix(get): Fix from_id cache-misses

### DIFF
--- a/chimedb/dataset/get.py
+++ b/chimedb/dataset/get.py
@@ -105,14 +105,14 @@ class DatasetState(orm.DatasetState):
             try:
                 _logger.debug(f"Loading state {state_id} from database...")
                 if load_data:
-                    _state_cache[state_id] = DatasetState.get(
-                        DatasetState.id == state_id
-                    )
+                    _state_cache[state_id] = DatasetState.get_by_id(state_id)
                 else:
-                    _state_cache[state_id] = DatasetState.select(
-                        DatasetState.type, DatasetState.time
-                    ).get()
-            except orm.DatasetState.DoesNotExist:
+                    _state_cache[state_id] = (
+                        DatasetState.select(DatasetState.type, DatasetState.time)
+                        .where(DatasetState.id == state_id)
+                        .get()
+                    )
+            except DatasetState.DoesNotExist:
                 _logger.warning(f"Could not find state {state_id}.")
                 return None
         return _state_cache[state_id]
@@ -191,8 +191,8 @@ class Dataset(orm.Dataset):
             )
         if ds_id not in _dataset_cache:
             try:
-                _dataset_cache[ds_id] = Dataset.get(Dataset.id == ds_id)
-            except orm.Dataset.DoesNotExist:
+                _dataset_cache[ds_id] = Dataset.get_by_id(ds_id)
+            except Dataset.DoesNotExist:
                 _logger.warning(f"Could not find dataset {ds_id}.")
                 return None
         return _dataset_cache[ds_id]

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -106,3 +106,17 @@ class TestDataset(TestChimeDB):
         # pre-fetch
         dget.index()
         tests()
+
+    def test_get_missing(self):
+        # These don't exist
+        assert dget.Dataset.from_id("42") is None
+        assert dget.DatasetState.from_id("42") is None
+
+        # But these do
+        ds = dget.Dataset.from_id("1337")
+        assert ds is not None
+        assert ds.id == "1337"
+
+        state = dget.DatasetState.from_id("23")
+        assert state is not None
+        assert state.id == "23"


### PR DESCRIPTION
Fixes both `get.Dataset.from_id` and `get.DatasetState.from_id`.

I don't think these ever worked when the item was not already in the cache.

It may be related to the fact that the tests labelled `..._no_prefetch` are explicitly pre-fetching before running, meaning there was no coverage of this code in the test-suite.